### PR TITLE
fix: parseResponseHeaders with empty string return ealier

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -116,8 +116,11 @@ export const data2QueryString = (data: Record<string, any>) => {
  * @returns 响应头对象
  */
 export const parseResponseHeaders = (headerString: string) => {
-	const headersAry = headerString.trim().split(/[\r\n]+/);
 	const headersMap = {} as AlovaXHRResponseHeaders;
+	if (headerString === '') {
+		return headersMap;
+	}
+	const headersAry = headerString.trim().split(/[\r\n]+/);
 	headersAry.forEach(line => {
 		const [headerName, value] = line.split(/:\s*/);
 		headersMap[headerName] = value;

--- a/test/helper.spec.ts
+++ b/test/helper.spec.ts
@@ -1,0 +1,14 @@
+import { parseResponseHeaders } from '../src/helper';
+
+describe('parseResponseHeaders tests', () => {
+	test('mvp test', () => {
+		const header = parseResponseHeaders('x-powered-by: msw');
+		expect(Object.keys(header).length).toBe(1);
+		expect(header['x-powered-by']).toBe('msw');
+	});
+
+	test('empty header', () => {
+		const header = parseResponseHeaders('');
+		expect(Object.keys(header).length).toBe(0);
+	});
+});


### PR DESCRIPTION
parseResponseHeaders 参数为空字符串时提早返回，避免出现 `{ '': undefined }` 对象